### PR TITLE
Fix incorrect variable name when saving options;

### DIFF
--- a/options.js
+++ b/options.js
@@ -3,7 +3,7 @@ const saveOptions = () => {
     const auto = document.getElementById('auto').checked;
 
     chrome.storage.sync.set(
-        { instance, auto },
+        { apiurl, auto },
         () => {
             alert('Options saved.')
         }


### PR DESCRIPTION
Custom instance URLs weren't saved because they persisted the wrong variable when calling `storage.set`