### PR TITLE
Changed default Cobalt instance for YouTube compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supports setting cobalt instance and if to press save button automatically.
 ![Screenshot](https://lune.dimden.dev/e9db75a55a.png)  
 
 ### Install
-Add it as an 'unpacked extension' to Chrome/Chromium (after enabling Developer Mode), 
+Add it as an 'unpacked extension' to Chrome/Chromium (after enabling Developer Mode), go to 'Install Add-on From File...' in the Firefox extensions menu and point it to the Firefox release zip file (you may need to set xpinstall.signatures.required to false in about:config to disable signature checks)
   
   
 Powered by [cobalt](https://github.com/wukko/cobalt/).  

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ Supports setting cobalt instance and if to press save button automatically.
 ![Screenshot](https://lune.dimden.dev/e9db75a55a.png)  
 
 ### Install
-Add the unzipped folder using the 'unpacked extension' option to Chrome/Chromium extensions menu (after enabling Developer Mode), go to 'Install Add-on From File...' in the Firefox extensions menu and point it to the Firefox release zip file (you may need to set xpinstall.signatures.required to false in about:config to disable signature checks)
-  
+**Firefox:** [Firefox Addons](https://addons.mozilla.org/uk/firefox/addon/cobalt-downloader/)
+
+**Chrome/Chromium:** Please install it manually by downloading the Chrome release of this repo and loading it as unpacked extension (after enabling Developer Mode).
   
 Powered by [cobalt](https://github.com/wukko/cobalt/).  
 
-Original repo made by [dimdenGD](https://github.com/dimdenGD), fix made by [kivir](https://github.com/kivirnz)
-
-(The reason why this fork was made was because you couldn't set the instance manually in the Firefox version, only in the Chrome/Chromium version)
+Repo made by [dimdenGD](https://github.com/dimdenGD), fix made by [kivir](https://github.com/kivirnz)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supports setting cobalt instance and if to press save button automatically.
 ![Screenshot](https://lune.dimden.dev/e9db75a55a.png)  
 
 ### Install
-Add it as an 'unpacked extension' to Chrome/Chromium (after enabling Developer Mode), go to 'Install Add-on From File...' in the Firefox extensions menu and point it to the Firefox release zip file (you may need to set xpinstall.signatures.required to false in about:config to disable signature checks)
+Add the unzipped folder using the 'unpacked extension' option to Chrome/Chromium extensions menu (after enabling Developer Mode), go to 'Install Add-on From File...' in the Firefox extensions menu and point it to the Firefox release zip file (you may need to set xpinstall.signatures.required to false in about:config to disable signature checks)
   
   
 Powered by [cobalt](https://github.com/wukko/cobalt/).  

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ Supports setting cobalt instance and if to press save button automatically.
 ![Screenshot](https://lune.dimden.dev/e9db75a55a.png)  
 
 ### Install
-~~**Chrome, Opera, Brave & Chromium browsers:** [Chrome Web Store](https://chrome.google.com/webstore/detail/cobalt-downloader/aljdknakoehcmmhflhfakfabbohhlohn)~~ Chrome Web Store is not approving updates anymore, please install it manually by downloading Code of this repo and loading it as unpacked extension.   
-**Firefox:** [Firefox Addons](https://addons.mozilla.org/uk/firefox/addon/cobalt-downloader/)  
+Add it as an 'unpacked extension' to Chrome/Chromium (after enabling Developer Mode), 
   
   
 Powered by [cobalt](https://github.com/wukko/cobalt/).  
+
+Original repo made by [dimdenGD](https://github.com/dimdenGD), fix made by [kivir](https://github.com/kivirnz)
+
+(The reason why this fork was made was because you couldn't set the instance manually in the Firefox version, only in the Chrome/Chromium version)

--- a/background.js
+++ b/background.js
@@ -65,7 +65,7 @@ chrome.action.onClicked.addListener(tab => {
         return;
     }
     chrome.storage.sync.get(
-        { apiurl: 'api.cobalt.tools' },
+        { apiurl: 'cobalt.meowing.de' },
         (items) => {
             downloadItem(items.apiurl, tab.url);
         }
@@ -75,14 +75,14 @@ chrome.action.onClicked.addListener(tab => {
 chrome.contextMenus.onClicked.addListener((info, tab) => {  
     if(info.menuItemId === "download-media-from-link") {
         chrome.storage.sync.get(
-            { apiurl: 'api.cobalt.tools' },
+            { apiurl: 'cobalt.meowing.de' },
             (items) => {
                 downloadItem(items.apiurl, info.linkUrl)
             }
         );
     } else if(info.menuItemId === "download-media-from-page") {
         chrome.storage.sync.get(
-            { apiurl: 'api.cobalt.tools' },
+            { apiurl: 'cobalt.meowing.de' },
             (items) => {
                 downloadItem(items.apiurl, tab.url);
             }

--- a/content_script.js
+++ b/content_script.js
@@ -1,5 +1,5 @@
 chrome.storage.sync.get(
-    { instance: 'cobalt.tools', auto: true },
+    { instance: 'cobalt.meowing.de', auto: true },
     (items) => {
         const u = new URLSearchParams(window.location.search).get('u');
         if(location.host === items.instance && items.auto && u) {

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "declarativeNetRequestWithHostAccess"
   ],
   "host_permissions": [
-    "*://*.cobalt.tools/*"
+    "*://*.cobalt.meowing.de/*"
   ],
   "icons": {
     "128": "/images/co.png"

--- a/options.html
+++ b/options.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <h1>cobalt extension options</h1>
-    instance: <input value="cobalt.tools" id="instance" placeholder="instance"><br><br>
+    instance: <input value="cobalt.meowing.de" id="instance" placeholder="instance"><br><br>
     press on save button automatically: <input type="checkbox" id="auto" style="vertical-align:sub"><br><br>
     <button id="save">save</button>
     <br><br>

--- a/options.js
+++ b/options.js
@@ -12,7 +12,7 @@ const saveOptions = () => {
 
 const restoreOptions = () => {
     chrome.storage.sync.get(
-        { apiurl: 'api.cobalt.tools', auto: true },
+        { apiurl: 'cobalt.meowing.de', auto: true },
         (items) => {
             document.getElementById('instance').value = items.apiurl;
             document.getElementById('auto').checked = items.auto;

--- a/ruleset.json
+++ b/ruleset.json
@@ -8,7 +8,7 @@
                 {
                     "header": "origin",
                     "operation": "set",
-                    "value": "https://cobalt.tools"
+                    "value": "https://cobalt.meowing.de"
                 },
                 {
                     "header": "referer",
@@ -22,7 +22,7 @@
             ]
         },
         "condition": {
-            "urlFilter": "||cobalt.tools/*",
+            "urlFilter": "||cobalt.meowing.de/*",
             "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "font", "xmlhttprequest", "other"]
         }
     }


### PR DESCRIPTION
The YouTube function of the main cobalt.tools instance was taken offline a while ago, devs are refusing to fix it.
This fork switches the default one to cobalt.meowing.de which does allow for YouTube downloading.
I know that you can change the default instance in the extension itself, however you can't do so in Firefox, only in Chrome/Chromium